### PR TITLE
Add trials data interface

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 neuroconv
 nwbwidgets
 nwbinspector
+pre-commit

--- a/src/jazayeri_lab_to_nwb/watters/__init__.py
+++ b/src/jazayeri_lab_to_nwb/watters/__init__.py
@@ -1,2 +1,3 @@
 from .wattersbehaviorinterface import WattersBehaviorInterface
+from .watterstrialsinterface import WattersTrialsInterface
 from .wattersnwbconverter import WattersNWBConverter

--- a/src/jazayeri_lab_to_nwb/watters/watters_convert_session.py
+++ b/src/jazayeri_lab_to_nwb/watters/watters_convert_session.py
@@ -17,35 +17,45 @@ def session_to_nwb(data_dir_path: Union[str, Path], output_dir_path: Union[str, 
         output_dir_path = output_dir_path / "nwb_stub"
     output_dir_path.mkdir(parents=True, exist_ok=True)
 
-    session_id = "subject_identifier_usually"
+    session_id = f"20220601-trials"
     nwbfile_path = output_dir_path / f"{session_id}.nwb"
 
     source_data = dict()
     conversion_options = dict()
 
     # Add Recording
-    source_data.update(dict(Recording=dict()))
-    conversion_options.update(dict(Recording=dict()))
+    # source_data.update(dict(Recording=dict()))
+    # conversion_options.update(dict(Recording=dict()))
 
     # Add LFP
-    source_data.update(dict(LFP=dict()))
-    conversion_options.update(dict(LFP=dict()))
+    # source_data.update(dict(LFP=dict()))
+    # conversion_options.update(dict(LFP=dict()))
 
     # Add Sorting
-    source_data.update(dict(Sorting=dict()))
-    conversion_options.update(dict(Sorting=dict()))
+    # source_data.update(dict(Sorting=dict()))
+    # conversion_options.update(dict(Sorting=dict()))
 
     # Add Behavior
-    source_data.update(dict(Behavior=dict()))
-    conversion_options.update(dict(Behavior=dict()))
+    # source_data.update(dict(Behavior=dict()))
+    # conversion_options.update(dict(Behavior=dict()))
+
+    # Add Trials
+    source_data.update(dict(Trials=dict(folder_path=str(data_dir_path / "data_open_source"))))
+    conversion_options.update(dict(Trials=dict()))
 
     converter = WattersNWBConverter(source_data=source_data)
 
     # Add datetime to conversion
     metadata = converter.get_metadata()
-    datetime.datetime(year=2020, month=1, day=1, tzinfo=ZoneInfo("US/Eastern"))
-    date = datetime.datetime.today()  # TO-DO: Get this from author
+    date = datetime.datetime(year=2022, month=6, day=1, tzinfo=ZoneInfo("US/Eastern"))
     metadata["NWBFile"]["session_start_time"] = date
+    metadata["NWBFile"]["session_id"] = session_id
+
+    # Subject name
+    if "monkey0" in str(data_dir_path):
+        metadata["Subject"]["subject_id"] = "Perle"
+    elif "monkey1" in str(data_dir_path):
+        metadata["Subject"]["subject_id"] = "Elgar"
 
     # Update default metadata with the editable in the corresponding yaml file
     editable_metadata_path = Path(__file__).parent / "watters_metadata.yaml"
@@ -59,9 +69,9 @@ def session_to_nwb(data_dir_path: Union[str, Path], output_dir_path: Union[str, 
 if __name__ == "__main__":
 
     # Parameters for conversion
-    data_dir_path = Path("/Directory/With/Raw/Formats/")
-    output_dir_path = Path("~/conversion_nwb/")
-    stub_test = False
+    data_dir_path = Path("/shared/catalystneuro/JazLab/monkey0/2022-06-01/")
+    output_dir_path = Path("~/conversion_nwb/jazayeri-lab-to-nwb/watters_perle_trials/").expanduser()
+    stub_test = True
 
     session_to_nwb(
         data_dir_path=data_dir_path,

--- a/src/jazayeri_lab_to_nwb/watters/watters_metadata.yaml
+++ b/src/jazayeri_lab_to_nwb/watters/watters_metadata.yaml
@@ -1,14 +1,14 @@
 NWBFile:
-  related_publications:
-    https://doi.org/### or link to APA or MLA citation of the publication
+  # related_publications:
+  #   - https://doi.org/12345
   session_description:
     A rich text description of the experiment. Can also just be the abstract of the publication.
-  institution: Institution where the lab is located
+  institution: MIT
   lab: Jazayeri
   experimenter:
-    - Last, First Middle
-    - Last, First Middle
+    - Watters, Nicholas
 Subject:
-  species: Rattus norvegicus
-  age: TBD  # in ISO 8601, such as "P1W2D"
-  sex: TBD  # One of M, F, U, or O
+  species: Macaca mulatta
+  # subject_id: monkey0
+  age: P6Y  # in ISO 8601, such as "P1W2D"
+  sex: U  # One of M, F, U, or O

--- a/src/jazayeri_lab_to_nwb/watters/wattersnwbconverter.py
+++ b/src/jazayeri_lab_to_nwb/watters/wattersnwbconverter.py
@@ -6,15 +6,19 @@ from neuroconv.datainterfaces import (
     PhySortingInterface,
 )
 
-from jazayeri_lab_to_nwb.watters import WattersBehaviorInterface
+from jazayeri_lab_to_nwb.watters import (
+    WattersBehaviorInterface,
+    WattersTrialsInterface,
+)
 
 
 class WattersNWBConverter(NWBConverter):
     """Primary conversion class for my extracellular electrophysiology dataset."""
 
     data_interface_classes = dict(
-        Recording=SpikeGLXRecordingInterface,
-        LFP=SpikeGLXLFPInterface,
-        Sorting=PhySortingInterface,
-        Behavior=WattersBehaviorInterface,
+        # Recording=SpikeGLXRecordingInterface,
+        # LFP=SpikeGLXLFPInterface,
+        # Sorting=PhySortingInterface,
+        # Behavior=WattersBehaviorInterface,
+        Trials=WattersTrialsInterface,
     )

--- a/src/jazayeri_lab_to_nwb/watters/watterstrialsinterface.py
+++ b/src/jazayeri_lab_to_nwb/watters/watterstrialsinterface.py
@@ -1,20 +1,33 @@
 """Primary class for converting experiment-specific behavior."""
 import json
 import numpy as np
+import pandas as pd
 from pathlib import Path
 from pynwb import NWBFile
+from typing import Optional
 
-from neuroconv.basedatainterface import BaseDataInterface
-from neuroconv.utils import DeepDict, FolderPathType
+from neuroconv.datainterfaces.text.timeintervalsinterface import TimeIntervalsInterface
+from neuroconv.utils import DeepDict, FolderPathType, FilePathType
 
 
-class WattersTrialsInterface(BaseDataInterface):
-    def __init__(self, folder_path: FolderPathType):
-        super().__init__(folder_path=folder_path)
+class WattersTrialsInterface(TimeIntervalsInterface):
+    def __init__(self, folder_path: FolderPathType, verbose: bool = True):
+        super().__init__(file_path=folder_path, verbose=verbose)
 
-    def add_to_nwbfile(self, nwbfile: NWBFile, metadata: dict):
-        # check that all data exist
-        folder_path = Path(self.source_data["folder_path"])
+    def get_metadata(self) -> dict:
+        metadata = super().get_metadata()
+        metadata["TimeIntervals"] = dict(
+            trials=dict(
+                table_name="trials",
+                table_description=f"experimental trials generated from JSON files",
+            )
+        )
+
+        return metadata
+
+    def _read_file(self, file_path: FolderPathType):
+        # define files to read
+        folder_path = Path(file_path)
         all_fields = [
             "behavior/trials.broke_fixation.json",
             "behavior/trials.response.error.json",
@@ -27,6 +40,8 @@ class WattersTrialsInterface(BaseDataInterface):
             "task/trials.reward.time.json",
             "task/trials.stimuli_init.json",
         ]
+
+        # check that all data exist
         for field in all_fields:
             assert (folder_path / field).exists(), f"Could not find {folder_path / field}"
 
@@ -36,81 +51,25 @@ class WattersTrialsInterface(BaseDataInterface):
             with open(folder_path / field, "r") as f:
                 data_dict[field] = json.load(f)
 
-        # add trial columns
-        nwbfile.add_trial_column(
-            name="broke_fixation", description="Whether the subject broke fixation before the response period."
-        )
-        nwbfile.add_trial_column(
-            name="response_error",
-            description="Euclidean distance between subject's response fixation position and the true target object's position, in units of display sidelength.",
-        )
-        nwbfile.add_trial_column(
-            name="response_location",
-            description="Position of the subject's response fixation, in units of display sidelength, with (0,0) being the bottom left corner of the display.",
-        )
-        nwbfile.add_trial_column(
-            name="response_object",
-            description="The ID of the stimulus object nearest to the subject's response, one of 'a' for Apple, 'b' for Blueberry, or 'c' for Orange. If the trial ended prematurely, the field is left blank.",
-        )
-        nwbfile.add_trial_column(
-            name="object_blank",
-            description="Whether the object locations were visible in the delay phase as blank disks.",
-        )
-        nwbfile.add_trial_column(name="stimulus_time", description="Time of stimulus presentation.")
-        nwbfile.add_trial_column(name="delay_start_time", description="Time of the beginning of the delay period.")
-        nwbfile.add_trial_column(name="cue_time", description="Time of cue object presentation.")
-        nwbfile.add_trial_column(name="response_time", description="Time of subject's response.")
-        nwbfile.add_trial_column(name="reveal_time", description="Time of reveal of correct object position.")
-        nwbfile.add_trial_column(name="reward_duration", description="Duration of juice reward, in seconds.")
-        nwbfile.add_trial_column(name="reward_time", description="Time of reward delivery.")
-        nwbfile.add_trial_column(
-            name="target_object",
-            description="ID of the stimulus object that is the target object, one of 'a' for Apple, 'b' for Blueberry, or 'c' for Orange.",
-        )
-        nwbfile.add_trial_column(
-            name="object_a_position",
-            index=True,
-            description="Position of stimulus object 'a', or Apple. Values are (x,y) coordinates in units of screen sidelength, with (0,0) being the bottom left corner. If the object is not presented in a particular trial, the position is empty.",
-        )
-        nwbfile.add_trial_column(
-            name="object_a_velocity",
-            index=True,
-            description="Velocity of stimulus object 'a', or Apple. Values are (x,y) velocity vectors, in units of screen sidelength per simulation timestep. If the object is not presented in a particular trial, the velocity is empty.",
-        )
-        nwbfile.add_trial_column(
-            name="object_b_position",
-            index=True,
-            description="Position of stimulus object 'b', or Blueberry. Values are (x,y) coordinates in units of screen sidelength, with (0,0) being the bottom left corner. If the object is not presented in a particular trial, the position is empty.",
-        )
-        nwbfile.add_trial_column(
-            name="object_b_velocity",
-            index=True,
-            description="Velocity of stimulus object 'b', or Blueberry. Values are (x,y) velocity vectors, in units of screen sidelength per simulation timestep. If the object is not presented in a particular trial, the velocity is empty.",
-        )
-        nwbfile.add_trial_column(
-            name="object_c_position",
-            index=True,
-            description="Position of stimulus object 'c', or Orange. Values are (x,y) coordinates in units of screen sidelength, with (0,0) being the bottom left corner. If the object is not presented in a particular trial, the position is empty.",
-        )
-        nwbfile.add_trial_column(
-            name="object_c_velocity",
-            index=True,
-            description="Velocity of stimulus object 'c', or Orange. Values are (x,y) velocity vectors, in units of screen sidelength per simulation timestep. If the object is not presented in a particular trial, the velocity is empty.",
-        )
+        # define useful helpers
+        get_by_index = lambda lst, idx: np.nan if (idx >= len(lst)) else lst[idx]
+        none_to_nan = lambda val, dim: val or (np.nan if dim <= 1 else np.full((dim,), np.nan).tolist())
 
-        # add trials to table
+        # process trial data
+        processed_data = []
         n_trials = len(data_dict["task/trials.start_times.json"])
         for i in range(n_trials):
+            # get trial start time
             start_time = data_dict["task/trials.start_times.json"][i]
-            get_by_index = lambda lst, idx: np.nan if (idx >= len(lst)) else lst[idx]
-            none_to_nan = lambda val, dim: val or (np.nan if dim <= 1 else np.full((dim,), np.nan).tolist())
 
+            # map response object index to id
             response_object = data_dict["behavior/trials.response.object.json"][i]
             if response_object is None:
                 response_object = ""
             else:
                 response_object = data_dict["task/trials.stimuli_init.json"][i][response_object]["id"]
 
+            # map stimuli info from list to corresponding ids
             object_info = {"a": {}, "b": {}, "c": {}}
             target_object = None
             for object_dict in data_dict["task/trials.stimuli_init.json"][i]:
@@ -122,28 +81,66 @@ class WattersTrialsInterface(BaseDataInterface):
                     target_object = object_id
             assert target_object is not None
 
-            nwbfile.add_trial(
-                start_time=start_time,
-                stop_time=start_time + data_dict["task/trials.relative_phase_times.json"][i][-1],
-                broke_fixation=data_dict["behavior/trials.broke_fixation.json"][i],
-                response_error=none_to_nan(data_dict["behavior/trials.response.error.json"][i], 1),
-                response_location=none_to_nan(data_dict["behavior/trials.response.location.json"][i], 2),
-                response_object=response_object,
-                object_blank=data_dict["task/trials.object_blanks.json"][i],
-                stimulus_time=start_time + get_by_index(data_dict["task/trials.relative_phase_times.json"][i], 0),
-                delay_start_time=start_time + get_by_index(data_dict["task/trials.relative_phase_times.json"][i], 1),
-                cue_time=start_time + get_by_index(data_dict["task/trials.relative_phase_times.json"][i], 2),
-                response_time=start_time + get_by_index(data_dict["task/trials.relative_phase_times.json"][i], 3),
-                reveal_time=start_time + get_by_index(data_dict["task/trials.relative_phase_times.json"][i], 4),
-                reward_duration=none_to_nan(data_dict["task/trials.reward.duration.json"][i], 1),
-                reward_time=start_time + none_to_nan(data_dict["task/trials.reward.time.json"][i], 1),
-                target_object=target_object,
-                object_a_position=object_info["a"].get("position", []),
-                object_a_velocity=object_info["a"].get("velocity", []),
-                object_b_position=object_info["b"].get("position", []),
-                object_b_velocity=object_info["b"].get("velocity", []),
-                object_c_position=object_info["c"].get("position", []),
-                object_c_velocity=object_info["c"].get("velocity", []),
+            processed_data.append(
+                dict(
+                    start_time=start_time,
+                    stop_time=start_time + data_dict["task/trials.relative_phase_times.json"][i][-1],
+                    broke_fixation=data_dict["behavior/trials.broke_fixation.json"][i],
+                    response_error=none_to_nan(data_dict["behavior/trials.response.error.json"][i], 1),
+                    response_location=none_to_nan(data_dict["behavior/trials.response.location.json"][i], 2),
+                    response_object=response_object,
+                    object_blank=data_dict["task/trials.object_blanks.json"][i],
+                    stimulus_time=start_time + get_by_index(data_dict["task/trials.relative_phase_times.json"][i], 0),
+                    delay_start_time=start_time
+                    + get_by_index(data_dict["task/trials.relative_phase_times.json"][i], 1),
+                    cue_time=start_time + get_by_index(data_dict["task/trials.relative_phase_times.json"][i], 2),
+                    response_time=start_time + get_by_index(data_dict["task/trials.relative_phase_times.json"][i], 3),
+                    reveal_time=start_time + get_by_index(data_dict["task/trials.relative_phase_times.json"][i], 4),
+                    reward_duration=none_to_nan(data_dict["task/trials.reward.duration.json"][i], 1),
+                    reward_time=start_time + none_to_nan(data_dict["task/trials.reward.time.json"][i], 1),
+                    target_object=target_object,
+                    object_a_position=object_info["a"].get("position", [np.nan, np.nan]),
+                    object_a_velocity=object_info["a"].get("velocity", [np.nan, np.nan]),
+                    object_b_position=object_info["b"].get("position", [np.nan, np.nan]),
+                    object_b_velocity=object_info["b"].get("velocity", [np.nan, np.nan]),
+                    object_c_position=object_info["c"].get("position", [np.nan, np.nan]),
+                    object_c_velocity=object_info["c"].get("velocity", [np.nan, np.nan]),
+                )
             )
 
-        return nwbfile
+        return pd.DataFrame(processed_data)
+
+    def add_to_nwbfile(
+        self,
+        nwbfile: NWBFile,
+        metadata: Optional[dict] = None,
+        tag: str = "trials",
+    ):
+        column_descriptions = {
+            "broke_fixation": "Whether the subject broke fixation before the response period.",
+            "response_error": "Euclidean distance between subject's response fixation position and the true target object's position, in units of display sidelength.",
+            "response_location": "Position of the subject's response fixation, in units of display sidelength, with (0,0) being the bottom left corner of the display.",
+            "response_object": "The ID of the stimulus object nearest to the subject's response, one of 'a' for Apple, 'b' for Blueberry, or 'c' for Orange. If the trial ended prematurely, the field is left blank.",
+            "object_blank": "Whether the object locations were visible in the delay phase as blank disks.",
+            "stimulus_time": "Time of stimulus presentation.",
+            "delay_start_time": "Time of the beginning of the delay period.",
+            "cue_time": "Time of cue object presentation.",
+            "response_time": "Time of subject's response.",
+            "reveal_time": "Time of reveal of correct object position.",
+            "reward_duration": "Duration of juice reward, in seconds.",
+            "reward_time": "Time of reward delivery.",
+            "target_object": "ID of the stimulus object that is the target object, one of 'a' for Apple, 'b' for Blueberry, or 'c' for Orange.",
+            "object_a_position": "Position of stimulus object 'a', or Apple. Values are (x,y) coordinates in units of screen sidelength, with (0,0) being the bottom left corner. If the object is not presented in a particular trial, the position is empty.",
+            "object_a_velocity": "Velocity of stimulus object 'a', or Apple. Values are (x,y) velocity vectors, in units of screen sidelength per simulation timestep. If the object is not presented in a particular trial, the velocity is empty.",
+            "object_b_position": "Position of stimulus object 'b', or Blueberry. Values are (x,y) coordinates in units of screen sidelength, with (0,0) being the bottom left corner. If the object is not presented in a particular trial, the position is empty.",
+            "object_b_velocity": "Velocity of stimulus object 'b', or Blueberry. Values are (x,y) velocity vectors, in units of screen sidelength per simulation timestep. If the object is not presented in a particular trial, the velocity is empty.",
+            "object_c_position": "Position of stimulus object 'c', or Orange. Values are (x,y) coordinates in units of screen sidelength, with (0,0) being the bottom left corner. If the object is not presented in a particular trial, the position is empty.",
+            "object_c_velocity": "Velocity of stimulus object 'c', or Orange. Values are (x,y) velocity vectors, in units of screen sidelength per simulation timestep. If the object is not presented in a particular trial, the velocity is empty.",
+        }
+
+        return super().add_to_nwbfile(
+            nwbfile=nwbfile,
+            metadata=metadata,
+            tag=tag,
+            column_descriptions=column_descriptions,
+        )

--- a/src/jazayeri_lab_to_nwb/watters/watterstrialsinterface.py
+++ b/src/jazayeri_lab_to_nwb/watters/watterstrialsinterface.py
@@ -1,0 +1,93 @@
+"""Primary class for converting experiment-specific behavior."""
+import json
+import numpy as np
+from pathlib import Path
+from pynwb import NWBFile
+
+from neuroconv.basedatainterface import BaseDataInterface
+from neuroconv.utils import DeepDict, FolderPathType
+
+
+class WattersTrialsInterface(BaseDataInterface):
+    def __init__(self, folder_path: FolderPathType):
+        super().__init__(folder_path=folder_path)
+
+    def add_to_nwbfile(self, nwbfile: NWBFile, metadata: dict):
+        # check that all data exist
+        folder_path = Path(self.source_data["folder_path"])
+        all_fields = [
+            "behavior/trials.broke_fixation.json",
+            "behavior/trials.response.error.json",
+            "behavior/trials.response.location.json",
+            "behavior/trials.response.object.json",
+            "task/trials.object_blanks.json",
+            "task/trials.start_times.json",
+            "task/trials.relative_phase_times.json",
+            "task/trials.reward.duration.json",
+            "task/trials.reward.time.json",
+            # 'task/trials.stimuli_init.json',
+        ]
+        for field in all_fields:
+            assert (folder_path / field).exists(), f"Could not find {folder_path / field}"
+
+        # load into a dictionary
+        data_dict = {}
+        for field in all_fields:
+            with open(folder_path / field, "r") as f:
+                data_dict[field] = json.load(f)
+
+        # add trial columns
+        nwbfile.add_trial_column(
+            name="broke_fixation", description="Whether the subject broke fixation before the response period."
+        )
+        nwbfile.add_trial_column(
+            name="response_error",
+            description="Euclidean distance between subject's response fixation position and the true target object's position, in units of display sidelength.",
+        )
+        nwbfile.add_trial_column(
+            name="response_location",
+            description="Position of the subject's response fixation, in units of display sidelength, with (0,0) being the bottom left corner of the display.",
+        )
+        nwbfile.add_trial_column(
+            name="response_object", description="The index of the stimulus object nearst to the subject's response."
+        )
+        nwbfile.add_trial_column(
+            name="object_blank",
+            description="Whether the object locations were visible in the delay phase as blank disks.",
+        )
+        nwbfile.add_trial_column(name="stimulus_time", description="Time of stimulus presentation.")
+        nwbfile.add_trial_column(name="delay_start_time", description="Time of the beginning of the delay period.")
+        nwbfile.add_trial_column(name="cue_time", description="Time of cue object presentation.")
+        nwbfile.add_trial_column(name="response_time", description="Time of subject's response.")
+        nwbfile.add_trial_column(name="reveal_time", description="Time of reveal of correct object position.")
+        nwbfile.add_trial_column(name="reward_duration", description="Duration of juice reward, in seconds.")
+        nwbfile.add_trial_column(name="reward_time", description="Time of reward delivery.")
+        # nwbfile.add_trial_column(name="stimuli_init", index=True, description="Description of the stimulus objects. For each object, the values are (x position, y position, x velocity, y velocity, object id, target) where position and velocity are floats in units of display sidelength, object id is 'a' for apple, 'b' for blueberry, and 'c' for orange, and target is a boolean indicating whether the given object is the target object.")
+
+        # add trials to table
+        n_trials = len(data_dict["task/trials.start_times.json"])
+        for i in range(n_trials):
+            start_time = data_dict["task/trials.start_times.json"][i]
+            # struct_dtype = [('x', float), ('y', float), ('x_vel', float), ('y_vel', float), ('id', 'U10'), ('target', bool)]
+            # stimuli_init = [np.array([[d['x'], d['y'], d['x_vel'], d['y_vel'], d['id'], d['target']]], dtype=struct_dtype) for d in data_dict['task/trials.stimuli_init.json'][i]]
+            get_by_index = lambda lst, idx: np.nan if (idx >= len(lst)) else lst[idx]
+            none_to_nan = lambda val, dim: val or (np.nan if dim <= 1 else np.full((dim,), np.nan).tolist())
+            nwbfile.add_trial(
+                start_time=start_time,
+                stop_time=start_time + data_dict["task/trials.relative_phase_times.json"][i][-1],
+                broke_fixation=data_dict["behavior/trials.broke_fixation.json"][i],
+                response_error=none_to_nan(data_dict["behavior/trials.response.error.json"][i], 1),
+                response_location=none_to_nan(data_dict["behavior/trials.response.location.json"][i], 2),
+                response_object=none_to_nan(data_dict["behavior/trials.response.object.json"][i], 1),
+                object_blank=data_dict["task/trials.object_blanks.json"][i],
+                stimulus_time=get_by_index(data_dict["task/trials.relative_phase_times.json"][i], 0),
+                delay_start_time=get_by_index(data_dict["task/trials.relative_phase_times.json"][i], 1),
+                cue_time=get_by_index(data_dict["task/trials.relative_phase_times.json"][i], 2),
+                response_time=get_by_index(data_dict["task/trials.relative_phase_times.json"][i], 3),
+                reveal_time=get_by_index(data_dict["task/trials.relative_phase_times.json"][i], 4),
+                reward_duration=none_to_nan(data_dict["task/trials.reward.duration.json"][i], 1),
+                reward_time=none_to_nan(data_dict["task/trials.reward.time.json"][i], 1),
+                # stimuli_init=stimuli_init,
+            )
+
+        return nwbfile

--- a/src/jazayeri_lab_to_nwb/watters/watterstrialsinterface.py
+++ b/src/jazayeri_lab_to_nwb/watters/watterstrialsinterface.py
@@ -118,9 +118,18 @@ class WattersTrialsInterface(TimeIntervalsInterface):
     ):
         column_descriptions = {
             "broke_fixation": "Whether the subject broke fixation before the response period.",
-            "response_error": "Euclidean distance between subject's response fixation position and the true target object's position, in units of display sidelength.",
-            "response_location": "Position of the subject's response fixation, in units of display sidelength, with (0,0) being the bottom left corner of the display.",
-            "response_object": "The ID of the stimulus object nearest to the subject's response, one of 'a' for Apple, 'b' for Blueberry, or 'c' for Orange. If the trial ended prematurely, the field is left blank.",
+            "response_error": (
+                "Euclidean distance between subject's response fixation position and the true target "
+                "object's position, in units of display sidelength."
+            ),
+            "response_location": (
+                "Position of the subject's response fixation, in units of display sidelength, with (0,0) "
+                "being the bottom left corner of the display."
+            ),
+            "response_object": (
+                "The ID of the stimulus object nearest to the subject's response, one of 'a' for Apple, "
+                "'b' for Blueberry, or 'c' for Orange. If the trial ended prematurely, the field is left blank."
+            ),
             "object_blank": "Whether the object locations were visible in the delay phase as blank disks.",
             "stimulus_time": "Time of stimulus presentation.",
             "delay_start_time": "Time of the beginning of the delay period.",
@@ -129,13 +138,40 @@ class WattersTrialsInterface(TimeIntervalsInterface):
             "reveal_time": "Time of reveal of correct object position.",
             "reward_duration": "Duration of juice reward, in seconds.",
             "reward_time": "Time of reward delivery.",
-            "target_object": "ID of the stimulus object that is the target object, one of 'a' for Apple, 'b' for Blueberry, or 'c' for Orange.",
-            "object_a_position": "Position of stimulus object 'a', or Apple. Values are (x,y) coordinates in units of screen sidelength, with (0,0) being the bottom left corner. If the object is not presented in a particular trial, the position is empty.",
-            "object_a_velocity": "Velocity of stimulus object 'a', or Apple. Values are (x,y) velocity vectors, in units of screen sidelength per simulation timestep. If the object is not presented in a particular trial, the velocity is empty.",
-            "object_b_position": "Position of stimulus object 'b', or Blueberry. Values are (x,y) coordinates in units of screen sidelength, with (0,0) being the bottom left corner. If the object is not presented in a particular trial, the position is empty.",
-            "object_b_velocity": "Velocity of stimulus object 'b', or Blueberry. Values are (x,y) velocity vectors, in units of screen sidelength per simulation timestep. If the object is not presented in a particular trial, the velocity is empty.",
-            "object_c_position": "Position of stimulus object 'c', or Orange. Values are (x,y) coordinates in units of screen sidelength, with (0,0) being the bottom left corner. If the object is not presented in a particular trial, the position is empty.",
-            "object_c_velocity": "Velocity of stimulus object 'c', or Orange. Values are (x,y) velocity vectors, in units of screen sidelength per simulation timestep. If the object is not presented in a particular trial, the velocity is empty.",
+            "target_object": (
+                "ID of the stimulus object that is the target object, one of 'a' for Apple, 'b' for Blueberry, "
+                "or 'c' for Orange."
+            ),
+            "object_a_position": (
+                "Position of stimulus object 'a', or Apple. Values are (x,y) coordinates in units of screen "
+                "sidelength, with (0,0) being the bottom left corner. If the object is not presented in a "
+                "particular trial, the position is empty."
+            ),
+            "object_a_velocity": (
+                "Velocity of stimulus object 'a', or Apple. Values are (x,y) velocity vectors, in units of "
+                "screen sidelength per simulation timestep. If the object is not presented in a particular "
+                "trial, the velocity is empty."
+            ),
+            "object_b_position": (
+                "Position of stimulus object 'b', or Blueberry. Values are (x,y) coordinates in units of "
+                "screen sidelength, with (0,0) being the bottom left corner. If the object is not presented "
+                "in a particular trial, the position is empty."
+            ),
+            "object_b_velocity": (
+                "Velocity of stimulus object 'b', or Blueberry. Values are (x,y) velocity vectors, in units "
+                "of screen sidelength per simulation timestep. If the object is not presented in a particular "
+                "trial, the velocity is empty."
+            ),
+            "object_c_position": (
+                "Position of stimulus object 'c', or Orange. Values are (x,y) coordinates in units of screen "
+                "sidelength, with (0,0) being the bottom left corner. If the object is not presented in a "
+                "particular trial, the position is empty."
+            ),
+            "object_c_velocity": (
+                "Velocity of stimulus object 'c', or Orange. Values are (x,y) velocity vectors, in units of "
+                "screen sidelength per simulation timestep. If the object is not presented in a particular "
+                "trial, the velocity is empty."
+            ),
         }
 
         return super().add_to_nwbfile(


### PR DESCRIPTION
Adding data interface for trials table. Inherits from `TimeIntervalsInterface`, currently opting for padding with NaNs instead of using empty lists for the position/velocity fields