### PR TITLE
Fix duplicated file identifiers from sharing metadata

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-neuroconv==0.4.3
+neuroconv>=0.4.3
 spikeinterface==0.98.2
 nwbwidgets
 nwbinspector

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-neuroconv>=0.4.3
+neuroconv==0.4.4
 spikeinterface==0.98.2
 nwbwidgets
 nwbinspector

--- a/src/jazayeri_lab_to_nwb/watters/watters_convert_session.py
+++ b/src/jazayeri_lab_to_nwb/watters/watters_convert_session.py
@@ -5,6 +5,7 @@ import datetime
 import glob
 import json
 from zoneinfo import ZoneInfo
+from uuid import uuid4
 
 from neuroconv.utils import load_dict_from_file, dict_deep_update
 
@@ -110,11 +111,12 @@ def session_to_nwb(data_dir_path: Union[str, Path], output_dir_path: Union[str, 
 
     # Add datetime to conversion
     metadata = processed_converter.get_metadata()  # use processed b/c it has everything
-    try:
-        date = datetime.datetime.strptime(data_dir_path.name, "%Y-%m-%d").replace(tzinfo=ZoneInfo("US/Eastern"))
-    except:
-        date = datetime.datetime(year=2022, month=6, day=1, tzinfo=ZoneInfo("US/Eastern"))
-    metadata["NWBFile"]["session_start_time"] = date
+    if "session_start_time" in metadata["NWBFile"]:
+        try:  # TODO fix
+            date = datetime.datetime.strptime(data_dir_path.name, "%Y-%m-%d").replace(tzinfo=ZoneInfo("US/Eastern"))
+        except:
+            date = datetime.datetime(year=2022, month=6, day=1, tzinfo=ZoneInfo("US/Eastern"))
+        metadata["NWBFile"]["session_start_time"] = date
     metadata["NWBFile"]["session_id"] = session_id
 
     # Subject name
@@ -147,6 +149,7 @@ def session_to_nwb(data_dir_path: Union[str, Path], output_dir_path: Union[str, 
         metadata=metadata, nwbfile_path=processed_nwbfile_path, conversion_options=processed_conversion_options
     )
 
+    metadata["NWBFile"]["identifier"] = str(uuid4())
     raw_converter = WattersNWBConverter(source_data=raw_source_data, sync_dir=str(data_dir_path / "sync_pulses"))
     raw_converter.run_conversion(
         metadata=metadata, nwbfile_path=raw_nwbfile_path, conversion_options=raw_conversion_options

--- a/src/jazayeri_lab_to_nwb/watters/watters_convert_session.py
+++ b/src/jazayeri_lab_to_nwb/watters/watters_convert_session.py
@@ -111,13 +111,6 @@ def session_to_nwb(data_dir_path: Union[str, Path], output_dir_path: Union[str, 
 
     # Add datetime to conversion
     metadata = processed_converter.get_metadata()  # use processed b/c it has everything
-    if "session_start_time" not in metadata["NWBFile"]:
-        try:
-            date = datetime.datetime.strptime(data_dir_path.name, "%Y-%m-%d").replace(tzinfo=ZoneInfo("US/Eastern"))
-        except:
-            print("Session start time not auto-detected. Setting to 2022-06-01...")
-            date = datetime.datetime(year=2022, month=6, day=1, tzinfo=ZoneInfo("US/Eastern"))
-        metadata["NWBFile"]["session_start_time"] = date
     metadata["NWBFile"]["session_id"] = session_id
 
     # Subject name
@@ -145,6 +138,16 @@ def session_to_nwb(data_dir_path: Union[str, Path], output_dir_path: Union[str, 
     editable_metadata = load_dict_from_file(editable_metadata_path)
     metadata = dict_deep_update(metadata, editable_metadata)
 
+    # check if session_start_time was found/set
+    if "session_start_time" not in metadata["NWBFile"]:
+        try:
+            date = datetime.datetime.strptime(data_dir_path.name, "%Y-%m-%d").replace(tzinfo=ZoneInfo("US/Eastern"))
+        except:
+            raise AssertionError(
+                "Session start time was not auto-detected. Please provide it in `watters_metadata.yaml`"
+            )
+        metadata["NWBFile"]["session_start_time"] = date
+
     # Run conversion
     processed_converter.run_conversion(
         metadata=metadata, nwbfile_path=processed_nwbfile_path, conversion_options=processed_conversion_options
@@ -163,7 +166,7 @@ if __name__ == "__main__":
     data_dir_path = Path("/shared/catalystneuro/JazLab/monkey0/2022-06-01/")
     # data_dir_path = Path("/shared/catalystneuro/JazLab/monkey1/2022-06-05/")
     output_dir_path = Path("~/conversion_nwb/jazayeri-lab-to-nwb/watters_perle_combined/").expanduser()
-    stub_test = False
+    stub_test = True
 
     session_to_nwb(
         data_dir_path=data_dir_path,

--- a/src/jazayeri_lab_to_nwb/watters/watters_convert_session.py
+++ b/src/jazayeri_lab_to_nwb/watters/watters_convert_session.py
@@ -112,9 +112,10 @@ def session_to_nwb(data_dir_path: Union[str, Path], output_dir_path: Union[str, 
     # Add datetime to conversion
     metadata = processed_converter.get_metadata()  # use processed b/c it has everything
     if "session_start_time" not in metadata["NWBFile"]:
-        try:  # TODO fix
+        try:
             date = datetime.datetime.strptime(data_dir_path.name, "%Y-%m-%d").replace(tzinfo=ZoneInfo("US/Eastern"))
         except:
+            print("Session start time not auto-detected. Setting to 2022-06-01...")
             date = datetime.datetime(year=2022, month=6, day=1, tzinfo=ZoneInfo("US/Eastern"))
         metadata["NWBFile"]["session_start_time"] = date
     metadata["NWBFile"]["session_id"] = session_id

--- a/src/jazayeri_lab_to_nwb/watters/watters_convert_session.py
+++ b/src/jazayeri_lab_to_nwb/watters/watters_convert_session.py
@@ -111,7 +111,7 @@ def session_to_nwb(data_dir_path: Union[str, Path], output_dir_path: Union[str, 
 
     # Add datetime to conversion
     metadata = processed_converter.get_metadata()  # use processed b/c it has everything
-    if "session_start_time" in metadata["NWBFile"]:
+    if "session_start_time" not in metadata["NWBFile"]:
         try:  # TODO fix
             date = datetime.datetime.strptime(data_dir_path.name, "%Y-%m-%d").replace(tzinfo=ZoneInfo("US/Eastern"))
         except:
@@ -162,7 +162,7 @@ if __name__ == "__main__":
     data_dir_path = Path("/shared/catalystneuro/JazLab/monkey0/2022-06-01/")
     # data_dir_path = Path("/shared/catalystneuro/JazLab/monkey1/2022-06-05/")
     output_dir_path = Path("~/conversion_nwb/jazayeri-lab-to-nwb/watters_perle_combined/").expanduser()
-    stub_test = True
+    stub_test = False
 
     session_to_nwb(
         data_dir_path=data_dir_path,

--- a/src/jazayeri_lab_to_nwb/watters/watters_metadata.yaml
+++ b/src/jazayeri_lab_to_nwb/watters/watters_metadata.yaml
@@ -1,14 +1,16 @@
 NWBFile:
-  # related_publications:
+  # related_publications: # no pubs yet
   #   - https://doi.org/12345
   session_description:
-    A rich text description of the experiment. Can also just be the abstract of the publication.
+    Data from macaque performing working memory task. Subject is presented with multiple objects at different locations
+    on a screen. After a delay, the subject is then cued with one of the objects, now displayed at the center of the
+    screen. Subject should respond by saccading to the location of the cued object at its initial presentation.
   institution: MIT
   lab: Jazayeri
   experimenter:
     - Watters, Nicholas
 Subject:
   species: Macaca mulatta
-  # subject_id: monkey0
+  # subject_id: Elgar # currently auto-detected from session path, but can be overridden here
   age: P6Y  # in ISO 8601, such as "P1W2D"
   sex: U  # One of M, F, U, or O

--- a/src/jazayeri_lab_to_nwb/watters/watterstrialsinterface.py
+++ b/src/jazayeri_lab_to_nwb/watters/watterstrialsinterface.py
@@ -63,11 +63,8 @@ class WattersTrialsInterface(TimeIntervalsInterface):
             # get trial start time
             start_time = data_dict["task/trials.start_times.json"][i]
             if np.isnan(start_time):
-                if i == 0:
-                    warnings.warn("Start time for first trial is NaN. Dropping this trial.", stacklevel=2)
-                    continue
-                else:
-                    raise ValueError(f"Start time for trial {i} is NaN.")
+                warnings.warn(f"Start time for trial {i} is NaN. Dropping this trial.", stacklevel=2)
+                continue
 
             # map response object index to id
             response_object = data_dict["behavior/trials.response.object.json"][i]

--- a/src/jazayeri_lab_to_nwb/watters/watterstrialsinterface.py
+++ b/src/jazayeri_lab_to_nwb/watters/watterstrialsinterface.py
@@ -2,6 +2,7 @@
 import json
 import numpy as np
 import pandas as pd
+import warnings
 from pathlib import Path
 from pynwb import NWBFile
 from typing import Optional
@@ -62,8 +63,11 @@ class WattersTrialsInterface(TimeIntervalsInterface):
             # get trial start time
             start_time = data_dict["task/trials.start_times.json"][i]
             if np.isnan(start_time):
-                print(f"Start time for trial {i} is NaN. Dropping this trial.")
-                continue
+                if i == 0:
+                    warnings.warn(f"Start time for first trial is NaN. Dropping this trial.")
+                    continue
+                else:
+                    raise ValueError(f"Start time for trial {i} is NaN.")
 
             # map response object index to id
             response_object = data_dict["behavior/trials.response.object.json"][i]

--- a/src/jazayeri_lab_to_nwb/watters/watterstrialsinterface.py
+++ b/src/jazayeri_lab_to_nwb/watters/watterstrialsinterface.py
@@ -64,7 +64,7 @@ class WattersTrialsInterface(TimeIntervalsInterface):
             start_time = data_dict["task/trials.start_times.json"][i]
             if np.isnan(start_time):
                 if i == 0:
-                    warnings.warn(f"Start time for first trial is NaN. Dropping this trial.")
+                    warnings.warn("Start time for first trial is NaN. Dropping this trial.", stacklevel=2)
                     continue
                 else:
                     raise ValueError(f"Start time for trial {i} is NaN.")

--- a/src/jazayeri_lab_to_nwb/watters/watterstrialsinterface.py
+++ b/src/jazayeri_lab_to_nwb/watters/watterstrialsinterface.py
@@ -62,11 +62,8 @@ class WattersTrialsInterface(TimeIntervalsInterface):
             # get trial start time
             start_time = data_dict["task/trials.start_times.json"][i]
             if np.isnan(start_time):
-                print(f"Start time for trial {i} is NaN. Assigning to the last trial's stop time.")
-                if i == 0:
-                    start_time = 0.0
-                else:
-                    start_time = processed_data[-1]["stop_time"]
+                print(f"Start time for trial {i} is NaN. Dropping this trial.")
+                continue
 
             # map response object index to id
             response_object = data_dict["behavior/trials.response.object.json"][i]

--- a/src/jazayeri_lab_to_nwb/watters/watterstrialsinterface.py
+++ b/src/jazayeri_lab_to_nwb/watters/watterstrialsinterface.py
@@ -61,6 +61,12 @@ class WattersTrialsInterface(TimeIntervalsInterface):
         for i in range(n_trials):
             # get trial start time
             start_time = data_dict["task/trials.start_times.json"][i]
+            if np.isnan(start_time):
+                print(f"Start time for trial {i} is NaN. Assigning to the last trial's stop time.")
+                if i == 0:
+                    start_time = 0.0
+                else:
+                    start_time = processed_data[-1]["stop_time"]
 
             # map response object index to id
             response_object = data_dict["behavior/trials.response.object.json"][i]


### PR DESCRIPTION
Main fix is manually generating new uuid before creating second NWBFile. Also added logic so that the auto-detected session start times from the SpikeGLX interface aren't overwritten unnecessarily, and fixed the `neuroconv` requirement after the recent schemas fix.