### PR TITLE
Fix session ID for automatic upload

### DIFF
--- a/src/jazayeri_lab_to_nwb/watters/watters_convert_session.py
+++ b/src/jazayeri_lab_to_nwb/watters/watters_convert_session.py
@@ -80,7 +80,7 @@ def session_to_nwb(
         output_dir_path = output_dir_path / "nwb_stub"
     output_dir_path.mkdir(parents=True, exist_ok=True)
 
-    session_id = f"ses-{data_dir.name}"
+    session_id = data_dir.name
     raw_nwbfile_path = output_dir_path / f"{session_id}_raw.nwb"
     processed_nwbfile_path = output_dir_path / f"{session_id}_processed.nwb"
     logging.info(f"raw_nwbfile_path = {raw_nwbfile_path}")


### PR DESCRIPTION
Automatic upload function automatically adjusts filename to always include session ID, which `dandi organize` only does when there's more than one session per subject (which we hadn't previously seen in initially shared data)

In this instance, it also depends on the uniqueness of the `data_dir_path`, which we can't see on the entire MIT side

I can eventually fix the helper in NeuroConv around this condition, but for now this should fix it

Will have to consider if including `ses-` in `nwbfile.session_id` is against best practice or not... strictly speaking the DANDI convention is to name file as `..._ses-{session_id}_...` so it would be weird to also have `ses-` in the session ID itself (source of issue here)

